### PR TITLE
change the file type to js after compiling

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = function (options) {
         sourceMaps: 'inline'
       });
       file.contents = results.code;
+      file.type = 'js';
     });
   };
 };

--- a/test/fixtures/es/index.es
+++ b/test/fixtures/es/index.es
@@ -1,0 +1,2 @@
+
+export var a = 1;

--- a/test/index.js
+++ b/test/index.js
@@ -27,8 +27,27 @@ describe('babel plugin', function () {
         assert.deepEqual(exec(file.contents), { a: 1 });
       });
   });
+
+  it('should convert other file types into js', function () {
+    let entry = fixture('es/index.es');
+
+    return mako()
+      .use(text('js'))
+      .use(babel())
+      .use(js())
+      .build(entry)
+      .then(function (tree) {
+        let file = tree.getFile(entry);
+        assert.equal(file.type, 'es');
+      });
+  });
 });
 
+/**
+ * Execute the JS string in a new context
+ * @param  {String} code javascript string
+ * @return {Mixed} value
+ */
 function exec(code) {
   return vm.runInNewContext(`${code}(1)`);
 }


### PR DESCRIPTION
This allows for passing in other file types like `jsx` and `es6`