### PR TITLE
Support/presets and plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = function (options) {
   let config = defaults(options, {
     extensions: 'js',
     ignore: [ /node_modules/i ],
+    plugins: [],
     only: null,
     sourceMaps: false
   });
@@ -31,7 +32,8 @@ module.exports = function (options) {
       debug('compiling %s', relative(file.path));
       let results = compile(file.contents, {
         filename: file.path,
-        sourceMaps: config.sourceMaps ? 'inline' : false
+        sourceMaps: config.sourceMaps ? 'inline' : false,
+        plugins: config.plugins
       });
 
       file.contents = results.code;

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = function (options) {
     extensions: 'js',
     ignore: [ /node_modules/i ],
     plugins: [],
+    presets: [],
     only: null,
     sourceMaps: false
   });
@@ -33,7 +34,8 @@ module.exports = function (options) {
       let results = compile(file.contents, {
         filename: file.path,
         sourceMaps: config.sourceMaps ? 'inline' : false,
-        plugins: config.plugins
+        plugins: config.plugins,
+        presets: config.presets
       });
 
       file.contents = results.code;


### PR DESCRIPTION
this is useful if you want to create plugins that consume `mako-babel` and you want to set certain plugins. Example (`mako-jsx`, `mako-flowtype`, etc.)

These plugins/presets are applied **in addition to** the plugins in `.babelrc`, so i don't see any downside in exposing these options.